### PR TITLE
feat(metrics): P1 seat-feed adapter — real Windows/Linux build+tests, numbers fail closed

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -36,6 +36,27 @@ jobs:
         run: |
           git submodule update --remote --merge
 
+      # Windows/Linux build+test numbers live ONLY on each repo's
+      # metrics-history branch — a master submodule checkout has none (the
+      # files 404 there). Fetch failures are logged loudly but do not fail
+      # the job: the collector fails closed and the platform publishes
+      # NOT-MEASURED, which is the honest state. No number is ever invented
+      # to keep a step green.
+      - name: Fetch seat metrics feeds (metrics-history)
+        run: |
+          for platform in windows linux; do
+            mkdir -p ".cache/metrics/${platform}"
+            base="https://raw.githubusercontent.com/hiwavebrowser/hiwave-${platform}/metrics-history"
+            if curl -fsSL "${base}/metrics/history.csv" -o ".cache/metrics/${platform}/history.csv"; then
+              echo "${platform}: history.csv fetched ($(wc -l < .cache/metrics/${platform}/history.csv) lines)"
+            else
+              echo "::warning::${platform}: metrics-history feed unreachable — platform will publish NOT-MEASURED"
+              rm -f ".cache/metrics/${platform}/history.csv"
+            fi
+            curl -fsSL "${base}/metrics.json" -o ".cache/metrics/${platform}/metrics.json" \
+              || rm -f ".cache/metrics/${platform}/metrics.json"
+          done
+
       - name: Collect platform metrics
         run: python3 scripts/collect_metrics.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ hiwave-web*
 __pycache__/
 *.pyc
 *.pyo
+
+# CI-fetched seat metrics feeds (metrics-history working copies)
+.cache/

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -11,11 +11,14 @@ Usage:
     python3 scripts/collect_metrics.py [--test] [--verbose]
 """
 
+import csv
+import io
 import json
 import sys
+import urllib.request
 from pathlib import Path
-from datetime import datetime
-from typing import Dict, Any, Optional, List
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional, List, Tuple
 import subprocess
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -47,6 +50,176 @@ SWARM_SOURCES = [
 
 # Unified results from CI aggregation
 UNIFIED_PARITY_FILE = METRICS_DIR / "parity_results.json"
+
+# ---------------------------------------------------------------------------
+# Seat metrics feeds (P1 adapter)
+#
+# Windows and Linux publish build + cargo-test results to an append-only
+# `metrics-history` branch in their own repos. Those numbers exist ONLY there:
+# a master checkout of the submodule has no metrics.json and no metrics/ dir,
+# which is why this collector used to print "No metrics found" for platforms
+# with green CI and hundreds of passing tests — it was reading a source that
+# is empty by construction (wrong source path + parity-only early return).
+#
+# The CI workflow drops each feed into .cache/metrics/<platform>/ before this
+# script runs; HTTPS raw is the fallback for local runs. A fetch failure
+# leaves the platform NOT-MEASURED — numbers fail closed, never invented.
+#
+# macOS is deliberately NOT wired here: its metrics-history schema is
+# parity-diff oriented and carries no build_ok. Its build badge staying
+# "unknown" is the honest state until a macOS seat publishes the Win/Linux
+# schema.
+SEAT_FEEDS = {
+    "windows": "https://raw.githubusercontent.com/hiwavebrowser/hiwave-windows/metrics-history",
+    "linux": "https://raw.githubusercontent.com/hiwavebrowser/hiwave-linux/metrics-history",
+}
+SEAT_CACHE_DIR = REPO_ROOT / ".cache" / "metrics"
+
+# A seat measurement older than this still publishes (it is real), but gets
+# flagged so a silently dead collector cannot keep wearing fresh-looking
+# numbers. Distinct from the badge-level 7-day STALE render threshold: this
+# one is provenance metadata in unified.json, that one is presentation.
+SEAT_STALE_AFTER_DAYS = 14
+
+HISTORY_CSV_COLUMNS = [
+    "timestamp", "commit", "branch", "build_ok",
+    "passed", "failed", "ignored", "warnings",
+]
+
+
+def parse_history_csv(text: str) -> Optional[Dict[str, str]]:
+    """Last master data row of a seat's metrics/history.csv, or None.
+
+    Row selection is pinned: skip the header, take the LAST row whose branch
+    is exactly "master" (case-sensitive, as written by the seats). PR-branch
+    rows never drive public numbers. No master row -> None, and the caller
+    publishes NOT-MEASURED rather than borrowing a branch row.
+    """
+    if not text:
+        return None
+    rows = list(csv.reader(io.StringIO(text)))
+    if not rows:
+        return None
+    header = [c.strip() for c in rows[0]]
+    if header[: len(HISTORY_CSV_COLUMNS)] != HISTORY_CSV_COLUMNS:
+        print(f"  Warning: unexpected history.csv header: {header}")
+        return None
+    last_master = None
+    for row in rows[1:]:
+        if len(row) < len(HISTORY_CSV_COLUMNS):
+            continue
+        if row[2].strip() == "master":
+            last_master = row
+    if last_master is None:
+        return None
+    return dict(zip(HISTORY_CSV_COLUMNS, (c.strip() for c in last_master)))
+
+
+def map_seat_metrics_to_unified(
+    platform: str,
+    row: Dict[str, str],
+    seat_json: Optional[Dict] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Map a seat CSV row to the unified platform object the badges consume.
+
+    Two rules here are load-bearing and pinned:
+
+    - tests_total is passed + failed, RECOMPUTED. The seat JSON's own "total"
+      currently equals passed alone, and ignored tests do not belong in the
+      denominator. A number we can recompute is never trusted pre-summed.
+    - There is NO parity key. Windows/Linux parity has never been measured;
+      the harness's 100.0-on-empty-capture default is exactly the lie this
+      whole stack exists to stop. The parity badge stays "no data".
+
+    git_commit is the commit the measurement was TAKEN AT (from the CSV row),
+    not whatever the submodule pointer happens to be today — restamping an old
+    measurement onto a current SHA is the fourth defect, and it does not come
+    back through this path.
+    """
+    passed = int(row["passed"])
+    failed = int(row["failed"])
+    metrics: Dict[str, Any] = {
+        "build": {"ok": row["build_ok"] == "True", "warnings": int(row["warnings"])},
+        "tests_passed": passed,
+        "tests_failed": failed,
+        "tests_ignored": int(row["ignored"]),
+        "tests_total": passed + failed,
+        "tests_source": "cargo",
+        "git_commit": row["commit"][:7],
+        "metrics_commit": row["commit"],
+        "measured_at": row["timestamp"],
+        "metrics_source": "metrics-history/history.csv",
+    }
+    if seat_json and isinstance(seat_json.get("not_collected"), dict):
+        metrics["not_collected"] = seat_json["not_collected"]
+
+    now = now or datetime.now(timezone.utc)
+    try:
+        measured = datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00"))
+        if measured.tzinfo is None:
+            measured = measured.replace(tzinfo=timezone.utc)
+        age_days = (now - measured).total_seconds() / 86400.0
+        if age_days > SEAT_STALE_AFTER_DAYS:
+            metrics["metrics_stale"] = True
+    except ValueError:
+        pass  # unparseable timestamp: publish without the flag, badge layer guards
+
+    return metrics
+
+
+def _read_url(url: str, timeout: int = 15) -> str:
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return resp.read().decode("utf-8")
+
+
+def fetch_seat_metrics(
+    platform: str,
+    cache_dir: Optional[Path] = None,
+    read_url=_read_url,
+) -> Tuple[Optional[Dict[str, str]], Optional[Dict]]:
+    """(last master CSV row, optional seat metrics.json) for a platform feed.
+
+    Source ranking is pinned: the CI-fetched cache file first, HTTPS raw as
+    fallback. Any failure returns (None, None) — fail closed. Numbers typed
+    into exchange messages, WORK_QUEUE pins, or design docs are never a
+    source; if the CSV cannot be read, the honest answer is NOT-MEASURED.
+    """
+    if platform not in SEAT_FEEDS:
+        return None, None
+    cache_dir = cache_dir if cache_dir is not None else SEAT_CACHE_DIR
+
+    csv_text = None
+    cache_csv = cache_dir / platform / "history.csv"
+    if cache_csv.exists():
+        csv_text = cache_csv.read_text()
+    else:
+        try:
+            csv_text = read_url(f"{SEAT_FEEDS[platform]}/metrics/history.csv")
+        except Exception as e:
+            print(f"  {platform}: seat feed unreachable ({e.__class__.__name__}) — "
+                  f"leaving NOT-MEASURED (numbers fail closed)")
+            return None, None
+
+    row = parse_history_csv(csv_text)
+    if row is None:
+        print(f"  {platform}: no master row in history.csv — leaving NOT-MEASURED")
+        return None, None
+
+    seat_json = None
+    cache_json = cache_dir / platform / "metrics.json"
+    if cache_json.exists():
+        try:
+            seat_json = json.loads(cache_json.read_text())
+        except Exception:
+            seat_json = None
+    else:
+        try:
+            seat_json = json.loads(read_url(f"{SEAT_FEEDS[platform]}/metrics.json"))
+        except Exception:
+            seat_json = None  # optional enrichment only; the CSV row stands alone
+
+    return row, seat_json
 
 
 def get_git_commit(submodule_path: Path) -> Optional[str]:
@@ -283,7 +456,13 @@ def collect_platform_metrics(platform: str, submodule_path: Path, verbose: bool 
     parity_data, parity_source = find_file(submodule_path, PARITY_TEST_SOURCES)
     baseline_data, baseline_source = find_file(submodule_path, BASELINE_SOURCES)
 
-    if not swarm_data and not parity_data and not baseline_data:
+    # Seat build/tests feed (Windows/Linux). Orthogonal to parity: either may
+    # populate a platform row. The old code returned None the moment parity
+    # artefacts were absent, which is the exact defect that kept two platforms
+    # grey through weeks of green CI.
+    seat_row, seat_json = fetch_seat_metrics(platform)
+
+    if not swarm_data and not parity_data and not baseline_data and not seat_row:
         print(f"  No metrics found for {platform}")
         return None
 
@@ -328,8 +507,18 @@ def collect_platform_metrics(platform: str, submodule_path: Path, verbose: bool 
             metrics["perf"] = baseline_metrics["perf"]
         metrics["tier_a_pass_rate"] = baseline_metrics.get("tier_a_pass_rate", 0)
 
-    # Add git commit
-    metrics["git_commit"] = get_git_commit(submodule_path)
+    if seat_row:
+        if seat_json:
+            print(f"  Found metrics-history feed (build + cargo tests, enriched)")
+        else:
+            print(f"  Found metrics-history feed (build + cargo tests)")
+        metrics.update(map_seat_metrics_to_unified(platform, seat_row, seat_json))
+
+    # Add git commit — only when the seat feed hasn't already pinned the
+    # commit the measurement was actually taken at. The submodule pointer is
+    # today's tree, not the measured tree.
+    if "git_commit" not in metrics:
+        metrics["git_commit"] = get_git_commit(submodule_path)
 
     return metrics
 
@@ -557,14 +746,21 @@ def main():
     for platform in ["macos", "windows", "linux"]:
         data = unified.get("platforms", {}).get(platform)
         if data:
-            parity = data.get("parity", 0)
+            parity = data.get("parity")
             source = data.get("parity_source", "unknown")
             passed = data.get("tests_passed", "?")
             total = data.get("tests_total", "?")
             grade = data.get("perf_grade", "?")
 
             print(f"\n  {platform.upper()}:")
-            print(f"    Visual Parity:  {parity:>6.2f}%  (source: {source})")
+            if parity is not None:
+                print(f"    Visual Parity:  {parity:>6.2f}%  (source: {source})")
+            else:
+                # No parity key means parity was never measured. Printing
+                # "0.00%" here would be the harness-100.0 defect inverted.
+                print(f"    Visual Parity:  not measured")
+            if data.get("tests_source"):
+                print(f"    Tests Source:   {data['tests_source']}")
             if data.get("builtins_parity"):
                 print(f"    - Builtins:     {data['builtins_parity']:>6.2f}%")
             if data.get("websuite_parity"):

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -355,16 +355,31 @@ def generate_all_badges(metrics: Dict[str, Any]) -> Dict[str, str]:
 
         badges[f"tests-{platform}.svg"] = generate_badge_svg("tests", value, color, label_width=40)
 
-    # Overall tests passing badge
-    total_passed = 0
-    total_tests = 0
-    for p in platforms.values():
-        if p and p.get("tests_passed") is not None:
-            total_passed += p.get("tests_passed", 0)
-            total_tests += p.get("tests_total", 0)
+    # Overall tests passing badge.
+    #
+    # Platforms do not all count the same thing: macOS's numbers are PARITY
+    # CASES (a 26-case pixel suite), Windows/Linux's are CARGO UNIT TESTS
+    # (hundreds per platform). Summing them into one fraction — 21/26 + 869/869
+    # rendered as 890/895 — is a number nobody measured, with the small honest
+    # denominator drowned by the large one. Same species as the missing
+    # parity denominator: true fields, lying total.
+    #
+    # Rule (pinned): once any platform reports cargo counts, overall
+    # aggregates ONLY platforms with the same tests_source, and the value
+    # names its source when other ontologies exist in the matrix. With no
+    # cargo platforms present, behaviour is unchanged.
+    with_tests = [
+        p for p in platforms.values() if p and p.get("tests_passed") is not None
+    ]
+    cargo = [p for p in with_tests if p.get("tests_source") == "cargo"]
+    pool = cargo if cargo else with_tests
+    source_tag = " · cargo" if cargo and len(cargo) < len(with_tests) else ""
+
+    total_passed = sum(p.get("tests_passed", 0) for p in pool)
+    total_tests = sum(p.get("tests_total", 0) for p in pool)
 
     if total_tests > 0:
-        value = f"{total_passed}/{total_tests}"
+        value = f"{total_passed}/{total_tests}{source_tag}"
         pass_rate = total_passed / total_tests
         if pass_rate >= 0.8:
             color = COLORS["green"]

--- a/scripts/tests/test_metrics_adapter.py
+++ b/scripts/tests/test_metrics_adapter.py
@@ -1,0 +1,298 @@
+"""The umbrella must report seat numbers it READ, or report nothing.
+
+These tests pin the P1 adapter: Windows/Linux build+test numbers flow from
+each seat's append-only metrics-history CSV into unified.json. The failure
+modes pinned here are the ones this project has actually shipped:
+
+  1. The collector returned None for any platform without parity artefacts,
+     so platforms with green CI and hundreds of passing tests stayed grey
+     for weeks (wrong source path + parity-only early return).
+  2. Numbers hand-typed from chat/design docs drifted from the CSV within a
+     day (the 869 -> 872 lesson). Only the CSV drives numbers here.
+  3. A parity value invented from build/tests/harness defaults. The parity
+     key must be ABSENT for seat-fed platforms — "no data" is the honest
+     badge until pixels are actually captured.
+  4. Cargo unit tests and parity cases summed into one fraction. Different
+     ontologies never share a denominator.
+
+No test in this file touches the network.
+"""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from collect_metrics import (  # noqa: E402
+    fetch_seat_metrics,
+    map_seat_metrics_to_unified,
+    parse_history_csv,
+)
+from generate_badges import generate_all_badges  # noqa: E402
+
+
+HEADER = "timestamp,commit,branch,build_ok,passed,failed,ignored,warnings\n"
+
+WINDOWS_ROW = (
+    "2026-07-30T11:30:49Z,30929cf1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,"
+    "master,True,869,0,5,49\n"
+)
+
+NOW = datetime(2026, 7, 31, 0, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# CSV row selection
+# ---------------------------------------------------------------------------
+
+class TestParseHistoryCsv:
+    def test_last_master_row_wins(self):
+        text = (
+            HEADER
+            + "2026-07-28T10:00:00Z,aaaa111,master,True,860,0,5,50\n"
+            + WINDOWS_ROW
+        )
+        row = parse_history_csv(text)
+        assert row["commit"].startswith("30929cf1")
+        assert row["passed"] == "869"
+
+    def test_branch_rows_never_drive_numbers(self):
+        # A PR-branch row NEWER than the last master row must not win.
+        text = (
+            HEADER
+            + WINDOWS_ROW
+            + "2026-07-30T23:59:59Z,fffffff,athena/some-branch,True,999,0,0,0\n"
+        )
+        row = parse_history_csv(text)
+        assert row["passed"] == "869"
+        assert row["branch"] == "master"
+
+    def test_no_master_row_returns_none(self):
+        text = HEADER + "2026-07-30T11:00:00Z,abc,pr-branch,True,10,0,0,0\n"
+        assert parse_history_csv(text) is None
+
+    def test_header_only_returns_none(self):
+        assert parse_history_csv(HEADER) is None
+
+    def test_empty_returns_none(self):
+        assert parse_history_csv("") is None
+
+    def test_unexpected_header_returns_none(self):
+        # A schema change on the producer side must fail closed, not misread
+        # columns positionally.
+        assert parse_history_csv("time,sha,ref\n2026,abc,master\n") is None
+
+    def test_widened_schema_appended_columns_ok(self):
+        # Windows PR #47 appended tests_ok + tests_exit_code to the CSV.
+        # APPENDED columns are compatible (prefix match); reordered or
+        # renamed ones are not. Live shape as of 2026-07-30:
+        text = (
+            "timestamp,commit,branch,build_ok,passed,failed,ignored,warnings,"
+            "tests_ok,tests_exit_code\n"
+            "2026-07-30T23:22:00Z,2bcbf0f4,master,True,896,0,5,49,True,0\n"
+        )
+        row = parse_history_csv(text)
+        assert row["passed"] == "896"
+        assert row["commit"] == "2bcbf0f4"
+
+
+# ---------------------------------------------------------------------------
+# Field mapping
+# ---------------------------------------------------------------------------
+
+def _windows_row():
+    return parse_history_csv(HEADER + WINDOWS_ROW)
+
+
+class TestFieldMap:
+    def test_total_is_passed_plus_failed_recomputed(self):
+        # The seat JSON's own "total" equals passed alone today, and ignored
+        # tests inflate the denominator. Recompute, never trust pre-summed.
+        row = parse_history_csv(
+            HEADER + "2026-07-30T11:30:49Z,abc1234,master,True,860,9,5,49\n"
+        )
+        m = map_seat_metrics_to_unified("windows", row, now=NOW)
+        assert m["tests_passed"] == 860
+        assert m["tests_failed"] == 9
+        assert m["tests_total"] == 869  # 860 + 9, ignored NOT included
+
+    def test_parity_key_is_absent(self):
+        m = map_seat_metrics_to_unified("windows", _windows_row(), now=NOW)
+        assert "parity" not in m
+        assert "parity_source" not in m
+
+    def test_build_dict_shape(self):
+        m = map_seat_metrics_to_unified("windows", _windows_row(), now=NOW)
+        assert m["build"] == {"ok": True, "warnings": 49}
+
+    def test_build_failing_row(self):
+        row = parse_history_csv(
+            HEADER + "2026-07-30T11:30:49Z,abc1234,master,False,0,3,0,12\n"
+        )
+        m = map_seat_metrics_to_unified("windows", row, now=NOW)
+        assert m["build"]["ok"] is False
+
+    def test_provenance_fields(self):
+        m = map_seat_metrics_to_unified("windows", _windows_row(), now=NOW)
+        assert m["tests_source"] == "cargo"
+        assert m["metrics_source"] == "metrics-history/history.csv"
+        assert m["git_commit"] == "30929cf"  # short form of the MEASURED commit
+        assert m["metrics_commit"].startswith("30929cf1")
+        assert m["measured_at"] == "2026-07-30T11:30:49Z"
+
+    def test_fresh_measurement_not_flagged_stale(self):
+        m = map_seat_metrics_to_unified("windows", _windows_row(), now=NOW)
+        assert "metrics_stale" not in m
+
+    def test_old_measurement_flagged_stale_but_still_published(self):
+        row = parse_history_csv(
+            HEADER + "2026-07-01T00:00:00Z,abc1234,master,True,800,0,5,49\n"
+        )
+        m = map_seat_metrics_to_unified("windows", row, now=NOW)
+        assert m["metrics_stale"] is True
+        assert m["tests_passed"] == 800  # published, not hidden
+
+    def test_not_collected_passthrough(self):
+        seat_json = {
+            "not_collected": {"parity_pixel_diff": "requires a GPU adapter"}
+        }
+        m = map_seat_metrics_to_unified(
+            "windows", _windows_row(), seat_json=seat_json, now=NOW
+        )
+        assert "parity_pixel_diff" in m["not_collected"]
+        assert "parity" not in m  # evidence NOT to invent a number
+
+
+# ---------------------------------------------------------------------------
+# Fetch: fail closed
+# ---------------------------------------------------------------------------
+
+def _no_network(url, timeout=15):
+    raise AssertionError(f"unexpected network call: {url}")
+
+
+class TestFetchFailClosed:
+    def test_unknown_platform_returns_nothing(self, tmp_path):
+        assert fetch_seat_metrics("macos", cache_dir=tmp_path, read_url=_no_network) == (None, None)
+
+    def test_cache_hit_never_touches_network(self, tmp_path):
+        d = tmp_path / "windows"
+        d.mkdir()
+        (d / "history.csv").write_text(HEADER + WINDOWS_ROW)
+        row, seat_json = fetch_seat_metrics(
+            "windows",
+            cache_dir=tmp_path,
+            read_url=lambda url, timeout=15: (_ for _ in ()).throw(
+                OSError("network down")
+            ),
+        )
+        assert row is not None and row["passed"] == "869"
+        assert seat_json is None  # metrics.json fetch failed -> optional, dropped
+
+    def test_fetch_failure_returns_nothing(self, tmp_path):
+        def dead(url, timeout=15):
+            raise OSError("connection refused")
+
+        assert fetch_seat_metrics("linux", cache_dir=tmp_path, read_url=dead) == (None, None)
+
+    def test_csv_without_master_row_returns_nothing(self, tmp_path):
+        d = tmp_path / "linux"
+        d.mkdir()
+        (d / "history.csv").write_text(
+            HEADER + "2026-07-30T11:00:00Z,abc,pr-branch,True,10,0,0,0\n"
+        )
+        assert fetch_seat_metrics("linux", cache_dir=tmp_path, read_url=_no_network) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Badge ontology guard (tests-overall)
+# ---------------------------------------------------------------------------
+
+def _svg_value(svg: str) -> str:
+    # The value string appears in the rendered SVG text nodes.
+    return svg
+
+
+class TestTestsOverallOntology:
+    def test_cargo_and_parity_cases_never_share_a_denominator(self):
+        metrics = {
+            "generated_at": "2026-07-30T12:00:00Z",
+            "platforms": {
+                "macos": {  # parity cases, no tests_source
+                    "parity": 88.1,
+                    "tests_passed": 21,
+                    "tests_total": 26,
+                    "last_updated": "2026-07-30T00:00:00Z",
+                },
+                "windows": {
+                    "tests_passed": 869,
+                    "tests_total": 869,
+                    "tests_source": "cargo",
+                },
+                "linux": {
+                    "tests_passed": 742,
+                    "tests_total": 742,
+                    "tests_source": "cargo",
+                },
+            },
+        }
+        svg = generate_all_badges(metrics)["tests-overall.svg"]
+        assert "1611/1611 · cargo" in _svg_value(svg)
+        # The forbidden mixed sum, in both orderings:
+        assert "1632/1637" not in svg
+        assert "890/895" not in svg
+
+    def test_macos_only_behaviour_unchanged(self):
+        metrics = {
+            "generated_at": "2026-07-30T12:00:00Z",
+            "platforms": {
+                "macos": {
+                    "parity": 88.1,
+                    "tests_passed": 21,
+                    "tests_total": 26,
+                    "last_updated": "2026-07-30T00:00:00Z",
+                },
+            },
+        }
+        svg = generate_all_badges(metrics)["tests-overall.svg"]
+        assert "21/26" in svg
+        assert "cargo" not in svg
+
+    def test_all_cargo_no_tag_needed(self):
+        metrics = {
+            "generated_at": "2026-07-30T12:00:00Z",
+            "platforms": {
+                "windows": {
+                    "tests_passed": 869,
+                    "tests_total": 869,
+                    "tests_source": "cargo",
+                },
+                "linux": {
+                    "tests_passed": 742,
+                    "tests_total": 742,
+                    "tests_source": "cargo",
+                },
+            },
+        }
+        svg = generate_all_badges(metrics)["tests-overall.svg"]
+        assert "1611/1611" in svg
+        assert "· cargo" not in svg  # no other ontology present to disambiguate
+
+    def test_seat_fed_platform_parity_badge_stays_no_data(self):
+        metrics = {
+            "generated_at": "2026-07-30T12:00:00Z",
+            "platforms": {
+                "windows": {
+                    "build": {"ok": True, "warnings": 49},
+                    "tests_passed": 869,
+                    "tests_total": 869,
+                    "tests_source": "cargo",
+                },
+            },
+        }
+        badges = generate_all_badges(metrics)
+        assert "no data" in badges["parity-windows.svg"]
+        assert "passing" in badges["build-windows.svg"]


### PR DESCRIPTION
## What

Wires the umbrella collector to the Windows/Linux `metrics-history` feeds so public badges show real build + cargo-test numbers, per Prometheus's P1 design pin (2026-07-30, IMPLEMENT_NOW).

**Stacked on #8** (base branch is `atlas/badge-honesty`) per the pin's dependency rule. Retarget to master after #8 merges.

## Why the platforms were grey

`collect_platform_metrics` looked only for parity artefacts under the submodule working tree and returned `None` when absent. Seat metrics exist **only** on each repo's `metrics-history` branch (404 on a master checkout). Wrong source path + parity-only early return — not missing numbers.

## Receipts (live CSV, this machine, at PR time)

| Platform | last master row |
|----------|-----------------|
| windows | `2026-07-30T23:22:00Z, 2bcbf0f4, master, build True, 896 passed / 0 failed / 5 ignored, 49 warn` |
| linux | `2026-07-30T21:05:27Z, af9280a6, master, build True, 759 passed / 0 failed / 5 ignored, 46 warn` |

Local `pytest scripts/tests/` → **37 passed / 0 failed** (14 badge-honesty + 23 adapter, all offline).
Live end-to-end run: both feeds ingested; badges would read `build passing`, `tests 896/896` / `759/759`, `parity no data`.

## Pinned rules implemented

- **Parity intentionally empty** for Windows/Linux — no `parity` key, badge stays "no data". `not_collected.parity_pixel_diff` passes through as the honesty trail.
- **tests_source: cargo** on seat-fed platforms; `tests-overall` never sums cargo tests with macOS parity cases — once cargo platforms report, overall is the cargo sum, tagged `· cargo` when another ontology is present.
- **Fetch path:** CI step drops feeds into `.cache/metrics/<platform>/` before collect (HTTPS raw fallback for local runs). Fetch failure → loud warning → platform publishes NOT-MEASURED. Fail closed on numbers, fail loud in the workflow.
- **tests_total = passed + failed, recomputed** — the seat JSON's own `total` equals `passed` alone; `ignored` is not a denominator.
- **git_commit = the measured commit** from the CSV row, not today's submodule pointer (the fourth defect does not return through this path).
- Last **master** row only; PR-branch rows never drive numbers even when newer. Windows' widened CSV (#47's `tests_ok,tests_exit_code`) parses by prefix; renamed/reordered schemas fail closed.
- **macOS not wired** — its metrics-history schema has no `build_ok`; build badge `unknown` remains the honest state.
- No `__pycache__`/`.pyc`; `.cache/` gitignored; no hand-filled `unified.json` rows; read-only consumer of `metrics-history`.

## R1

Pollux per the pin (§3 checklist: parity empty + no overall mix + CSV-driven). Atlas does not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qYdb9nqj7fLEmr2YKN6s3